### PR TITLE
Fix #8 - Styles for diff and recent to be usable on white theme

### DIFF
--- a/css/_diff.css
+++ b/css/_diff.css
@@ -13,8 +13,8 @@
     padding: 0;
     border-width: 0;
     /* no style.ini colours because deleted and added lines have a fixed background colour */
-    background-color: #fff;
-    color: #333;
+    background-color: #000;
+    color: #33B;
 }
 
 /* table header */
@@ -56,20 +56,20 @@
     font-weight: bold;
 }
 .dokuwiki table.diff .diff-addedline {
-    background-color: #cfc;
+    background-color: #4c3;
     color: inherit;
 }
 .dokuwiki table.diff .diff-deletedline {
-    background-color: #fdd;
+    background-color: #d33;
     color: inherit;
 }
 .dokuwiki table.diff td.diff-context {
-    background-color: #eee;
+    background-color: #000;
     color: inherit;
 }
 .dokuwiki table.diff td.diff-addedline strong,
 .dokuwiki table.diff td.diff-deletedline strong {
-    color: #f00;
+    color: #33b;
     background-color: inherit;
     font-weight: bold;
 }

--- a/css/_recent.css
+++ b/css/_recent.css
@@ -52,14 +52,14 @@
     border-radius: .2em;
     padding: .1em .2em;
     /* cannot use non-guaranteed style.ini colour placeholders, dark templates need to overwrite */
-    background-color: #ddd;
+    background-color: #333;
 }
 
 .dokuwiki form.changes li .sizechange.positive {
-    background-color: #cfc;;
+    background-color: #4c3;;
 }
 .dokuwiki form.changes li .sizechange.negative {
-    background-color: #fdd;
+    background-color: #d33;
 }
 
 /*____________ page navigator ____________*/


### PR DESCRIPTION
I am sure a graphic designer can do much better, however its at least readable now:

![2018-08-16 22_33_55-live map c_geo user guide](https://user-images.githubusercontent.com/949669/44233593-95848a80-a1a4-11e8-86b6-33f14f074910.png)

That was how it looked with the current version:
![2018-08-16 22_36_51-live map c_geo user guide](https://user-images.githubusercontent.com/949669/44233707-e7c5ab80-a1a4-11e8-9b15-c1bcfd5fa9eb.png)
